### PR TITLE
Add MySQL alpha data example web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ pip install -r wqbrain_app/requirements.txt
    Example:
 
 ```bash
-export MYSQL_URI="mysql+pymysql://user:password@localhost/wqbrain"
+export MYSQL_URI="mysql+pymysql://user:password@localhost:3306/wqbrain"
 ```
 
-3. Initialize the database and load alpha data:
+3. Optionally set `WQBRAIN_API_URL` to the endpoint that returns alpha data.
+
+4. Initialize the database and load alpha data:
 
 ```bash
 python -m wqbrain_app.load_alpha
 ```
 
-4. Run the web application:
+5. Run the web application:
 
 ```bash
 python -m wqbrain_app.webapp

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # my_first_repository
-this is my first new repository
+
+This repository contains an example project for fetching alpha data from the
+WQBrain platform, storing it in a MySQL database, and visualizing it on a web
+page.
+
+## Setup
+
+1. Install dependencies (preferably in a virtual environment):
+
+```bash
+pip install -r wqbrain_app/requirements.txt
+```
+
+2. Set the `MYSQL_URI` environment variable to point to your MySQL database.
+   Example:
+
+```bash
+export MYSQL_URI="mysql+pymysql://user:password@localhost/wqbrain"
+```
+
+3. Initialize the database and load alpha data:
+
+```bash
+python -m wqbrain_app.load_alpha
+```
+
+4. Run the web application:
+
+```bash
+python -m wqbrain_app.webapp
+```
+
+Then open `http://localhost:5000` to view the alpha data.
+
+## Notes
+
+- `fetch_alpha.py` contains a placeholder for the real API call to the
+  WQBrain platform. Update it with your API logic to retrieve alpha data.
+- The example uses Flask and SQLAlchemy.

--- a/wqbrain_app/__init__.py
+++ b/wqbrain_app/__init__.py
@@ -1,0 +1,5 @@
+"""WQBrain alpha viewer package."""
+
+from .webapp import app
+
+__all__ = ["app"]

--- a/wqbrain_app/database.py
+++ b/wqbrain_app/database.py
@@ -1,0 +1,13 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from .models import Base
+
+DB_URI = os.getenv('MYSQL_URI', 'mysql+pymysql://user:password@localhost/wqbrain')
+
+engine = create_engine(DB_URI)
+SessionLocal = sessionmaker(bind=engine)
+
+
+def init_db():
+    Base.metadata.create_all(engine)

--- a/wqbrain_app/database.py
+++ b/wqbrain_app/database.py
@@ -3,7 +3,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from .models import Base
 
-DB_URI = os.getenv('MYSQL_URI', 'mysql+pymysql://user:password@localhost/wqbrain')
+DB_URI = os.getenv(
+    "MYSQL_URI",
+    "mysql+pymysql://user:password@localhost:3306/wqbrain",
+)
 
 engine = create_engine(DB_URI)
 SessionLocal = sessionmaker(bind=engine)

--- a/wqbrain_app/fetch_alpha.py
+++ b/wqbrain_app/fetch_alpha.py
@@ -1,6 +1,8 @@
-"""Example module to fetch alpha data from the WQBrain platform."""
+"""Utility for fetching alpha data from the WQBrain platform."""
+
 import logging
-from typing import List, Dict
+import os
+from typing import Dict, List
 
 try:
     import requests
@@ -9,14 +11,34 @@ except ImportError:  # requests may not be installed
     logging.warning("requests library is missing; fetch_alpha will not work")
 
 
-# This is a placeholder. Update with real API calls to WQBrain.
-def fetch_alpha() -> List[Dict]:
-    """Return a list of dictionaries with alpha data."""
+def fetch_alpha() -> List[Dict[str, float]]:
+    """Fetch alpha data from the configured WQBrain API.
+
+    The URL is read from ``WQBRAIN_API_URL``. If the API call fails or the
+    ``requests`` library is missing, an empty list is returned.
+    """
+
     if requests is None:
         logging.error("requests library not installed")
         return []
 
-    # Example: response = requests.get('https://wqbrain.example/api/alpha')
-    # return response.json()
-    logging.info("fetch_alpha called, but no real API implemented")
-    return []
+    url = os.getenv("WQBRAIN_API_URL")
+    if not url:
+        logging.warning("WQBRAIN_API_URL is not set; returning empty data")
+        return []
+
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except Exception as exc:  # broad catch to keep the sample simple
+        logging.error("Failed to fetch alpha data: %s", exc)
+        return []
+
+    if not response.content:
+        return []
+
+    try:
+        return response.json()
+    except ValueError:
+        logging.error("Response was not valid JSON")
+        return []

--- a/wqbrain_app/fetch_alpha.py
+++ b/wqbrain_app/fetch_alpha.py
@@ -1,0 +1,22 @@
+"""Example module to fetch alpha data from the WQBrain platform."""
+import logging
+from typing import List, Dict
+
+try:
+    import requests
+except ImportError:  # requests may not be installed
+    requests = None
+    logging.warning("requests library is missing; fetch_alpha will not work")
+
+
+# This is a placeholder. Update with real API calls to WQBrain.
+def fetch_alpha() -> List[Dict]:
+    """Return a list of dictionaries with alpha data."""
+    if requests is None:
+        logging.error("requests library not installed")
+        return []
+
+    # Example: response = requests.get('https://wqbrain.example/api/alpha')
+    # return response.json()
+    logging.info("fetch_alpha called, but no real API implemented")
+    return []

--- a/wqbrain_app/load_alpha.py
+++ b/wqbrain_app/load_alpha.py
@@ -1,18 +1,24 @@
-"""Load alpha data from WQBrain into the local database."""
+"""Utility script to store alpha data from WQBrain into the database."""
+
+import logging
+
 from .database import SessionLocal, init_db
 from .models import Alpha
 from .fetch_alpha import fetch_alpha
 
 
-def main():
+def main() -> None:
+    """Fetch alpha records and persist them."""
+
     init_db()
     session = SessionLocal()
     try:
         alphas = fetch_alpha()
         for item in alphas:
-            alpha = Alpha(name=item.get('name'), value=item.get('value'))
+            alpha = Alpha(name=item.get("name"), value=item.get("value"))
             session.add(alpha)
         session.commit()
+        logging.info("Loaded %d alphas", len(alphas))
     finally:
         session.close()
 

--- a/wqbrain_app/load_alpha.py
+++ b/wqbrain_app/load_alpha.py
@@ -1,0 +1,21 @@
+"""Load alpha data from WQBrain into the local database."""
+from .database import SessionLocal, init_db
+from .models import Alpha
+from .fetch_alpha import fetch_alpha
+
+
+def main():
+    init_db()
+    session = SessionLocal()
+    try:
+        alphas = fetch_alpha()
+        for item in alphas:
+            alpha = Alpha(name=item.get('name'), value=item.get('value'))
+            session.add(alpha)
+        session.commit()
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/wqbrain_app/models.py
+++ b/wqbrain_app/models.py
@@ -10,3 +10,4 @@ class Alpha(Base):
     name = Column(String(255), nullable=False)
     value = Column(Float, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
+

--- a/wqbrain_app/models.py
+++ b/wqbrain_app/models.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Float, DateTime
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+class Alpha(Base):
+    __tablename__ = 'alpha'
+    id = Column(Integer, primary_key=True)
+    name = Column(String(255), nullable=False)
+    value = Column(Float, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)

--- a/wqbrain_app/requirements.txt
+++ b/wqbrain_app/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+SQLAlchemy
+PyMySQL
+requests

--- a/wqbrain_app/templates/index.html
+++ b/wqbrain_app/templates/index.html
@@ -8,8 +8,9 @@
   </style>
 </head>
 <body>
-<h1>Alpha Data</h1>
-<table>
+  <h1>Alpha Data</h1>
+  <p style="text-align: center"><a href="{{ url_for('refresh') }}">Refresh data</a></p>
+  <table>
   <thead>
     <tr>
       <th>ID</th>

--- a/wqbrain_app/templates/index.html
+++ b/wqbrain_app/templates/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+  <title>Alpha Data</title>
+  <style>
+    table {border-collapse: collapse; width: 80%; margin: auto;}
+    th, td {border: 1px solid #ccc; padding: 8px; text-align: left;}
+  </style>
+</head>
+<body>
+<h1>Alpha Data</h1>
+<table>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Name</th>
+      <th>Value</th>
+      <th>Timestamp</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for alpha in alphas %}
+    <tr>
+      <td>{{ alpha.id }}</td>
+      <td>{{ alpha.name }}</td>
+      <td>{{ alpha.value }}</td>
+      <td>{{ alpha.timestamp }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</body>
+</html>

--- a/wqbrain_app/webapp.py
+++ b/wqbrain_app/webapp.py
@@ -1,0 +1,24 @@
+from flask import Flask, render_template
+from .database import SessionLocal, init_db
+from .models import Alpha
+
+app = Flask(__name__)
+
+
+def get_alphas():
+    session = SessionLocal()
+    try:
+        return session.query(Alpha).order_by(Alpha.timestamp.desc()).all()
+    finally:
+        session.close()
+
+
+@app.route('/')
+def index():
+    alphas = get_alphas()
+    return render_template('index.html', alphas=alphas)
+
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)

--- a/wqbrain_app/webapp.py
+++ b/wqbrain_app/webapp.py
@@ -1,6 +1,8 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, redirect, url_for
+
 from .database import SessionLocal, init_db
 from .models import Alpha
+from .fetch_alpha import fetch_alpha
 
 app = Flask(__name__)
 
@@ -13,10 +15,28 @@ def get_alphas():
         session.close()
 
 
+def refresh_data() -> None:
+    """Fetch new alpha data and store it."""
+    session = SessionLocal()
+    try:
+        for item in fetch_alpha():
+            alpha = Alpha(name=item.get("name"), value=item.get("value"))
+            session.add(alpha)
+        session.commit()
+    finally:
+        session.close()
+
+
 @app.route('/')
 def index():
     alphas = get_alphas()
     return render_template('index.html', alphas=alphas)
+
+
+@app.route('/refresh')
+def refresh():
+    refresh_data()
+    return redirect(url_for('index'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add Python package `wqbrain_app` with SQLAlchemy model for alpha data
- include placeholder fetcher and loader scripts
- implement Flask web app and template for viewing alpha data
- document setup and usage in README

## Testing
- `python -m py_compile wqbrain_app/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555923f3708333998aeeecc1b34690